### PR TITLE
Added support for per-line-formatted RTF text

### DIFF
--- a/scripts/parser.js
+++ b/scripts/parser.js
@@ -24,8 +24,10 @@ var parser = (function() {
             return window.btoa(window.unescape(encodeURIComponent(str)));
         },
         stripRtf: function(str) {
-            //var pattern = /\{\*?\\[^{}]+}|[{}]|\\\n?[A-Za-z]+\n?(?:-?\d+)?[ ]?/g;
-            var basicRtfPattern = /\{\*?\\[^{}]+}|[{}]|\\[A-Za-z]+\n?(?:-?\d+)?[ ]?/g;
+            //var pattern =         /\{\*?\\[^{}]+}|[{}]|\\\n?[A-Za-z]+\n?(?:-?\d+)?[ ]?/g;
+            //var basicRtfPattern = /\{\*?\\[^{}]+}|[{}]|\\[A-Za-z]+\n?(?:-?\d+)?[ ]?/g;
+            var basicRtfPattern = /\{\*?\\[^{}]+;}|[{}]|\\[A-Za-z]+\n?(?:-?\d+)?[ ]?/g;
+            
             var newLineSlashesPattern = /\\\n/g;
 
             var stripped = str.replace(basicRtfPattern, "");


### PR DESCRIPTION
Updated `basicRtfPattern` regex from line 28. 

Current version supports lines formatted as:
`\f0\fs260 \cf1 \outl0\strokewidth0 \strokec1 Lyric lyric lyric \`
`Lyric lyric lyric\`
`\cf1 \outl0\strokewidth0 \strokec1 Lyric lyric}`

Proposed changes also allow support for lines formatted as:
`{\f3 {\cf2\ltrch Lyric lyric lyric}\li0\sa0\sb0\fi0\qc\par}`

Tested against sample pro4 & pro5 files